### PR TITLE
Close #5

### DIFF
--- a/src/jsondoc_json.erl
+++ b/src/jsondoc_json.erl
@@ -235,8 +235,6 @@ encode_array([], _First, Acc) -> [$]|Acc].
 item_separator(false, Acc) -> [$,|Acc];
 item_separator(_, Acc) -> Acc.
 
-encode_float(Value) when Value < 0.0000000001 andalso Value > -0.0000000001 ->
-	[float_to_binary(Value)];
 encode_float(Value) ->
 	float_to_binary(Value, [{decimals, 10}, compact]).
 


### PR DESCRIPTION
Removed the lines that caused the "-0.0000000001 and 0.0000000001" exception to encode_float.

Now,
1>  jsondoc:encode([{value, 0.0}]).
<<"{\"value\":0.0}">>
2>  jsondoc:encode([{value, 0.1}]).
<<"{\"value\":0.1}">>
3>  jsondoc:encode([{value, -0.1}]).
<<"{\"value\":-0.1}">>
4>  jsondoc:encode([{value, -0.1234567890}]).
<<"{\"value\":-0.123456789}">>